### PR TITLE
Pin urllib3 to 1.26.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
+    'urllib3==1.26.15',
     'colorlog',
     'docker==4.2.2',
     'PyYAML',


### PR DESCRIPTION
A recent update in urllib3 has deprecated some methods used. 
Although docker has solved this issue in https://github.com/docker/docker-py/issues/3113 , it persists on clusterdock (possibly due to pinning down docker package). 
